### PR TITLE
support for gamepad motion sticks

### DIFF
--- a/Input buffer/input_buffer.gd
+++ b/Input buffer/input_buffer.gd
@@ -72,9 +72,6 @@ func is_action_press_buffered(action: String) -> bool:
 				if delta <= BUFFER_WINDOW:
 					_invalidate_action(action)
 					return true
-	# If there's ever a third type of buffer-able action (mouse clicks maybe?), it'd probably be worth it to generalize
-	# the repetitive keyboard/joypad code into something that works for any input method. Until then, by the YAGNI 
-	# principle, the repetitive stuff stays >:)
 	
 	return false
 

--- a/Input buffer/input_buffer.gd
+++ b/Input buffer/input_buffer.gd
@@ -6,9 +6,12 @@ extends Node
 # How many milliseconds ahead of time the player can make an input and have it still be recognized.
 # I chose the value 150 because it imitates the 9-frame buffer window in the Super Smash Bros. Ultimate game.
 const BUFFER_WINDOW: int = 150
+# The godot default deadzone is 0.2 so I chose to have it the same
+const JOY_DEADZONE: float = 0.2
 
 var keyboard_timestamps: Dictionary
 var joypad_timestamps: Dictionary
+var joymotion_timestamps: Dictionary
 
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
@@ -17,6 +20,7 @@ func _ready() -> void:
 	# Initialize all dictionary entris.
 	keyboard_timestamps = {}
 	joypad_timestamps = {}
+	joymotion_timestamps = {}
 	
 
 # Called whenever the player makes an input.
@@ -33,6 +37,12 @@ func _input(event: InputEvent) -> void:
 			
 		var button_index: int = event.button_index
 		joypad_timestamps[button_index] = Time.get_ticks_msec()
+	elif event is InputEventJoypadMotion:
+		if abs(event.axis_value) < JOY_DEADZONE:
+			return
+			
+		var axis_code: String = str(event.axis) + "_" + str(sign(event.axis_value))
+		joymotion_timestamps[axis_code] = Time.get_ticks_msec()
 	
 # Returns whether any of the keyboard keys or joypad buttons in the given action were pressed within the buffer window.
 func is_action_press_buffered(action: String) -> bool:
@@ -51,6 +61,15 @@ func is_action_press_buffered(action: String) -> bool:
 			var button_index: int = event.button_index
 			if joypad_timestamps.has(button_index):
 				if Time.get_ticks_msec() - joypad_timestamps[button_index] <= BUFFER_WINDOW:
+					_invalidate_action(action)
+					return true
+		elif event is InputEventJoypadMotion:
+			if abs(event.axis_value) < JOY_DEADZONE:
+				return false
+			var axis_code: String = str(event.axis) + "_" + str(sign(event.axis_value))
+			if joymotion_timestamps.has(axis_code):
+				var delta = Time.get_ticks_msec() - joymotion_timestamps[axis_code]
+				if delta <= BUFFER_WINDOW:
 					_invalidate_action(action)
 					return true
 	# If there's ever a third type of buffer-able action (mouse clicks maybe?), it'd probably be worth it to generalize
@@ -72,3 +91,7 @@ func _invalidate_action(action: String) -> void:
 			var button_index: int = event.button_index
 			if joypad_timestamps.has(button_index):
 				joypad_timestamps[button_index] = 0
+		elif event is InputEventJoypadMotion:
+			var axis_code: String = str(event.axis) + "_" + str(sign(event.axis_value))
+			if joymotion_timestamps.has(axis_code):
+				joymotion_timestamps[axis_code] = 0

--- a/Input buffer/project.godot
+++ b/Input buffer/project.godot
@@ -39,6 +39,7 @@ ui_accept={
 , Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777232,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
 , Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":32,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
 , Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":12,"pressure":0.0,"pressed":false,"script":null)
+, Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":0,"axis":1,"axis_value":-1.0,"script":null)
  ]
 }
 


### PR DESCRIPTION
This PR adds support for the event `InputEventJoypadMotion`.
It uses a separate dictionary `joymotion_timestamps` to keep things clean and checks the action event against a `deadzone` constant to prevent drifting sticks to buffer endlessly.